### PR TITLE
Remove Prometheus references and add guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Guard: no Prometheus references
+        run: |
+          if git ls-files | xargs grep -nEi 'prometheus|collector:9333|(^|[^a-z])\\/metrics([^a-z]|$)'; then
+            echo "Prometheus references are not allowed in this repo."; exit 1;
+          fi
       - name: Guard: no wrapper dir
         run: |
           if [ -d "bitcoin-monitoring-stack" ]; then
             echo "Do not nest the project under bitcoin-monitoring-stack/"; exit 1;
-          fi
-      - name: Guard: no Prometheus endpoint wording
-        run: |
-          matches=$(git ls-files | xargs grep -nE "collector:9333|Prometheus option|\/metrics\b" || true)
-          if [ -n "$matches" ]; then
-            filtered=$(echo "$matches" | grep -v 'community exporter' || true)
-            if [ -n "$filtered" ]; then
-              echo "$filtered"
-              echo "Docs must not reference a Prometheus endpoint or collector:9333"
-              exit 1
-            fi
           fi
       - name: Guard: no binaries
         run: |

--- a/README.md
+++ b/README.md
@@ -21,12 +21,11 @@ An **easy-deploy** monitoring stack for **Bitcoin Core** node runners. One comma
 - [Common Pitfalls](#common-pitfalls)
 - [Uninstall / Clean Up](#uninstall--clean-up)
 - [License](#license)
-- [Prometheus Note](#prometheus-note)
 
 ---
 
 ## What You Get
-- **Collector → InfluxDB → Grafana** (no Prometheus endpoint)
+- **Collector → InfluxDB → Grafana** data flow
 - Blockchain sync & lag, mempool & fees, peer quality (geo/ASN), resource usage
 - Optional **Electrs/Fulcrum** `/stats` metrics
 - **Four prebuilt dashboards** (Overview, Sync & Health, Mempool & Fees, Peers & Geo)
@@ -95,7 +94,7 @@ In your external Grafana, add an **InfluxDB v2 (Flux)** datasource, then import 
 ---
 
 ## Bitcoin Core Setup
-The collector pulls metrics from Bitcoin Core via RPC (and optionally ZMQ). You do **not** point Bitcoin Core to this stack.
+The collector pulls metrics from Bitcoin Core via RPC (and optionally ZMQ); Bitcoin Core does not push metrics anywhere.
 
 Minimal `bitcoin.conf`:
 
@@ -228,7 +227,3 @@ docker compose down -v
 ## License
 MIT
 
----
-
-## Prometheus Note
-This stack does **not** expose a Prometheus endpoint or port 9333. All metrics flow Collector → InfluxDB → Grafana.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     container_name: btc_collector
     restart: unless-stopped
     env_file:
-      - ${ENV_FILE_PATH:-.env}
+      - ${ENV_FILE_PATH:-.env.example}
     volumes:
       - ${BITCOIN_DATADIR:-~/.bitcoin}:${BITCOIN_DATADIR:-/root/.bitcoin}:ro
     healthcheck:
@@ -61,7 +61,7 @@ services:
     container_name: btc_geoipupdate
     restart: unless-stopped
     env_file:
-      - ${ENV_FILE_PATH:-.env}
+      - ${ENV_FILE_PATH:-.env.example}
     environment:
       GEOIPUPDATE_ACCOUNT_ID: ${GEOIP_ACCOUNT_ID:-}
       GEOIPUPDATE_LICENSE_KEY: ${GEOIP_LICENSE_KEY:-}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@
 
 ## Bitcoin Core setup (important)
 The collector pulls metrics from Bitcoin Core via RPC (and optionally ZMQ).
-You do not point Bitcoin Core to a Prometheus or collector endpoint.
+Bitcoin Core is never reconfigured to emit metrics; the collector simply reads data it already exposes.
 
 Minimal bitcoin.conf:
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -4,7 +4,7 @@ All configuration is managed via the `.env` file (copied from `.env.example`). D
 
 ## Bitcoin Core setup (important)
 The collector pulls metrics from Bitcoin Core via RPC (and optionally ZMQ).
-You do not point Bitcoin Core to a Prometheus or collector endpoint.
+Bitcoin Core stays unchanged; the collector simply reads via RPC/ZMQ.
 
 Minimal bitcoin.conf:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -35,7 +35,7 @@ If the collector runs on the same machine as Bitcoin Core, it autodetects the co
 
 ### Bitcoin Core setup (important)
 The collector pulls metrics from Bitcoin Core via RPC (and optionally ZMQ).
-You do not point Bitcoin Core to a Prometheus or collector endpoint.
+Bitcoin Core does not send metrics outward; the collector polls the existing RPC/ZMQ interfaces.
 
 Minimal bitcoin.conf:
 


### PR DESCRIPTION
## Summary
- scrub Prometheus references from README and docs so they describe the Collector → InfluxDB v2 → Grafana flow
- point docker-compose env_file defaults at .env.example to avoid requiring a .env and keep only collector/influx/grafana/geoip services
- add a CI guard that fails when Prometheus wording or /metrics endpoints reappear

## Testing
- ⚠️ `pip install .[dev]` *(fails: upstream package index blocked by proxy in environment)*
- ⚠️ `ENV_FILE_PATH=.env.example docker compose config` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d18a938cd8832688335fc6f8b707d9