### PR TITLE
Clarify optional environment settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,19 +4,24 @@
 # --- Bitcoin Core ---
 BITCOIN_RPC_HOST=127.0.0.1
 BITCOIN_RPC_PORT=8332
-BITCOIN_RPC_USER=
-BITCOIN_RPC_PASSWORD=
-BITCOIN_RPC_COOKIE_PATH=~/.bitcoin/.cookie   # autodetect if local
+# Uncomment to provide explicit RPC credentials instead of cookie auth
+#BITCOIN_RPC_USER=
+#BITCOIN_RPC_PASSWORD=
+# Uncomment to point at a specific cookie file when autodetection fails
+#BITCOIN_RPC_COOKIE_PATH=~/.bitcoin/.cookie   # autodetect if local
 BITCOIN_NETWORK=mainnet
-BITCOIN_DATADIR=~/.bitcoin
-BITCOIN_CHAINSTATE_DIR=~/.bitcoin/chainstate
+# Uncomment to use a locally-mounted datadir instead of the default volume
+#BITCOIN_DATADIR=~/.bitcoin
+# Uncomment to enable disk usage metrics for an external chainstate path
+#BITCOIN_CHAINSTATE_DIR=~/.bitcoin/chainstate
 
 # ZMQ endpoints
 BITCOIN_ZMQ_RAWBLOCK=tcp://127.0.0.1:28332
 BITCOIN_ZMQ_RAWTX=tcp://127.0.0.1:28333
 
 # Optional Fulcrum/Electrs
-FULCRUM_STATS_URL=http://127.0.0.1:8080/stats
+# Uncomment to collect Fulcrum/Electrs statistics from a remote endpoint
+#FULCRUM_STATS_URL=http://127.0.0.1:8080/stats
 
 # --- InfluxDB ---
 USE_EXTERNAL_INFLUX=0
@@ -26,7 +31,8 @@ INFLUX_BUCKET=btc_metrics
 INFLUX_RETENTION_DAYS=60
 INFLUX_SETUP_USERNAME=admin
 INFLUX_SETUP_PASSWORD=admin123
-INFLUX_TOKEN=
+# Uncomment to supply an existing InfluxDB API token
+#INFLUX_TOKEN=
 
 # --- Grafana ---
 USE_EXTERNAL_GRAFANA=0
@@ -47,13 +53,15 @@ ENABLE_ASN_STATS=1
 
 # Mempool histogram: none | core_rawmempool | mempool_api
 MEMPOOL_HIST_SOURCE=none
-MEMPOOL_API_BASE=http://127.0.0.1:3006
+# Uncomment to pull mempool data from a configured mempool.space API
+#MEMPOOL_API_BASE=http://127.0.0.1:3006
 
 # Collector polling
 SCRAPE_INTERVAL_FAST=5
 SCRAPE_INTERVAL_SLOW=30
 
 # GeoIP
-GEOIP_ACCOUNT_ID=
-GEOIP_LICENSE_KEY=
+# Uncomment to add your MaxMind account credentials for GeoIP updates
+#GEOIP_ACCOUNT_ID=
+#GEOIP_LICENSE_KEY=
 GEOIP_UPDATE_FREQUENCY_DAYS=7


### PR DESCRIPTION
## Summary
- comment out optional environment variables in .env.example
- add guidance for when to enable RPC auth, datadir, Fulcrum, Influx, mempool, and GeoIP options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1bdecab388326a5c4af89c70147db