### PR TITLE
Clarify bind address defaults for remote access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,9 @@ USE_EXTERNAL_GRAFANA=0
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=admin
 EXPOSE_UI=0   # 0=localhost only; 1=expose to LAN (see HARDENING.md)
-GRAFANA_BIND_IP=127.0.0.1
-INFLUX_BIND_IP=127.0.0.1
+# When setting EXPOSE_UI=1 for remote access, update the bind addresses too.
+GRAFANA_BIND_IP=127.0.0.1   # Default binds to loopback; change to 0.0.0.0 or LAN IP when exposing beyond localhost.
+INFLUX_BIND_IP=127.0.0.1   # Default binds to loopback; change to 0.0.0.0 or LAN IP when exposing beyond localhost.
 
 # --- Feature Flags ---
 ENABLE_BLOCK_INTERVALS=1


### PR DESCRIPTION
## Summary
- explain that the default Grafana and InfluxDB bind IPs only expose services on loopback
- remind users to change the bind addresses when enabling remote access with EXPOSE_UI

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1c02527d08326b7fbc5ca17b4836c