### PR TITLE
Clarify mempool histogram configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,9 +52,12 @@ ENABLE_DISK_IO=1
 ENABLE_PEER_CHURN=1
 ENABLE_ASN_STATS=1
 
-# Mempool histogram: none | core_rawmempool | mempool_api
+# Mempool histogram source options:
+#   - Leave as "none" to disable the Grafana fee histogram.
+#   - Set to "core_rawmempool" to fetch the full verbose mempool on every fast scrape; this can be heavy.
+#   - Set to "mempool_api" to query the configured base URL for /api/v1/fees/recommended-style JSON buckets.
 MEMPOOL_HIST_SOURCE=none
-# Uncomment to pull mempool data from a configured mempool.space API
+# Uncomment to pull mempool data from any compatible mempool.space-style API service and ensure the stack can reach it over the network
 #MEMPOOL_API_BASE=http://127.0.0.1:3006
 
 # Collector polling


### PR DESCRIPTION
## Summary
- document how each MEMPOOL_HIST_SOURCE option affects the Grafana fee histogram and scraping load
- note that MEMPOOL_API_BASE can point to any compatible service and requires network reachability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1ca99a38c8326837b313693c9e1f0