### PR TITLE
Reorder optional feature flags in .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,10 +14,11 @@ BITCOIN_NETWORK=mainnet
 #BITCOIN_DATADIR=~/.bitcoin
 # Uncomment to enable disk usage metrics for an external chainstate path
 #BITCOIN_CHAINSTATE_DIR=~/.bitcoin/chainstate
+ENABLE_DISK_IO=1   # Samples disk utilisation for the chainstate directory when set to 1.
 
 # Optional ZMQ metrics (opt-in). Set ENABLE_ZMQ=1 and ensure the endpoints match `bitcoin.conf`.
-# Leave these commented when you are not collecting ZMQ metrics so dashboards skip the panels.
-#ENABLE_ZMQ=1
+# Leave ENABLE_ZMQ=0 and the endpoints commented when you are not collecting ZMQ metrics so dashboards skip the panels.
+ENABLE_ZMQ=0
 #BITCOIN_ZMQ_RAWBLOCK=tcp://127.0.0.1:28332
 #BITCOIN_ZMQ_RAWTX=tcp://127.0.0.1:28333
 
@@ -45,14 +46,15 @@ EXPOSE_UI=0   # 0=localhost only; 1=expose to LAN (see HARDENING.md)
 GRAFANA_BIND_IP=127.0.0.1   # Default binds to loopback; change to 0.0.0.0 or LAN IP when exposing beyond localhost.
 INFLUX_BIND_IP=127.0.0.1   # Default binds to loopback; change to 0.0.0.0 or LAN IP when exposing beyond localhost.
 
-# --- Feature Flags ---
-ENABLE_BLOCK_INTERVALS=1
-ENABLE_SOFTFORK_SIGNAL=1
-ENABLE_PEER_QUALITY=1
-ENABLE_PROCESS_METRICS=1
-ENABLE_DISK_IO=1
-ENABLE_PEER_CHURN=1
-ENABLE_ASN_STATS=1
+# --- Collector Analytics ---
+# Block analytics (placeholders for future dashboards)
+ENABLE_BLOCK_INTERVALS=1   # Placeholder flag for additional block cadence analytics.
+ENABLE_SOFTFORK_SIGNAL=1   # Placeholder flag for future softfork readiness panels.
+
+# Peer analytics and resource usage metrics
+ENABLE_PEER_QUALITY=1   # Enables peer latency aggregations.
+ENABLE_PEER_CHURN=1   # Reserved for future peer churn calculations.
+ENABLE_PROCESS_METRICS=1   # Collects CPU, memory, and file descriptor counts for bitcoind.
 
 # Mempool histogram source options:
 #   - Leave as "none" to disable the Grafana fee histogram.
@@ -65,6 +67,9 @@ MEMPOOL_HIST_SOURCE=none
 # Collector polling
 SCRAPE_INTERVAL_FAST=5
 SCRAPE_INTERVAL_SLOW=30
+
+# GeoIP enrichment
+ENABLE_ASN_STATS=1   # Adds ASN enrichment when GeoIP databases are available.
 
 # GeoIP
 # Uncomment to add your MaxMind account credentials for GeoIP updates

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -23,6 +23,7 @@ services. This document explains every option and how they interact.
 | `BITCOIN_NETWORK` | `mainnet` | Tag applied to every metric. Supports custom values such as `testnet` or `signet`. |
 | `BITCOIN_DATADIR` | `~/.bitcoin` | Mounted into the collector container to access the cookie file and configuration. |
 | `BITCOIN_CHAINSTATE_DIR` | `~/.bitcoin/chainstate` | Used when disk utilisation metrics are enabled. |
+| `ENABLE_DISK_IO` | `1` | Samples disk usage for the chainstate directory. |
 | `ENABLE_ZMQ` | `0` | Set to `1` to collect ZMQ freshness metrics. Leave at `0` when you do not need the Grafana ZMQ panels. |
 | `BITCOIN_ZMQ_RAWBLOCK` | `tcp://127.0.0.1:28332` | Endpoint for raw block notifications. Must match `bitcoin.conf` when ZMQ metrics are enabled. |
 | `BITCOIN_ZMQ_RAWTX` | `tcp://127.0.0.1:28333` | Endpoint for raw transaction notifications. Must match `bitcoin.conf` when ZMQ metrics are enabled. |
@@ -30,8 +31,10 @@ services. This document explains every option and how they interact.
 
 The collector automatically reads the cookie file when both username and password are empty.
 If the cookie cannot be found, make sure the data directory is mounted read-only into the
-container (see `docker-compose.yml`). When ZMQ metrics remain disabled the collector skips
-starting the listener and simply omits the corresponding measurements.
+container (see `docker-compose.yml`). Disk utilisation sampling also relies on the
+chainstate directory being available; disable `ENABLE_DISK_IO` when the path is not
+mounted. When ZMQ metrics remain disabled the collector skips starting the listener and
+simply omits the corresponding measurements.
 
 ## InfluxDB Options
 
@@ -71,9 +74,7 @@ changes to `INFLUX_*` variables should be reflected here as well.
 | `ENABLE_SOFTFORK_SIGNAL` | `1` | Placeholder flag for signalling dashboards. |
 | `ENABLE_PEER_QUALITY` | `1` | Enables peer latency aggregations. |
 | `ENABLE_PROCESS_METRICS` | `1` | Collects CPU, memory, and file descriptor counts for the `bitcoind` process using `psutil`. |
-| `ENABLE_DISK_IO` | `1` | Samples disk usage for the chainstate directory. |
 | `ENABLE_PEER_CHURN` | `1` | Reserved for future peer churn calculations. |
-| `ENABLE_ASN_STATS` | `1` | Enables ASN lookup fields when GeoIP data is available. |
 
 Flags marked as placeholders do not currently toggle additional logic but are included for
 future compatibility with dashboards.
@@ -96,9 +97,11 @@ When histogram collection is disabled (`none`), the collector skips external cal
 |----------|---------|-------------|
 | `GEOIP_ACCOUNT_ID` / `GEOIP_LICENSE_KEY` | _empty_ | MaxMind account credentials required to download GeoLite2 databases. |
 | `GEOIP_UPDATE_FREQUENCY_DAYS` | `7` | How often `geoipupdate` refreshes the databases. |
+| `ENABLE_ASN_STATS` | `1` | Enables ASN lookup fields when GeoIP data is available. |
 
 If credentials are omitted the update container will fail gracefully; peer metrics will still
-collect counts but without country/ASN enrichment.
+collect counts but without country/ASN enrichment. Toggle `ENABLE_ASN_STATS` off when you
+prefer to skip ASN lookups altogether.
 
 ## Customising for Testnet or Signet
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -54,7 +54,7 @@ Follow the steps that match your operating system:
    | `BITCOIN_RPC_HOST` / `BITCOIN_RPC_PORT` | Location of your Bitcoin Core RPC endpoint. |
    | `BITCOIN_RPC_USER` / `BITCOIN_RPC_PASSWORD` | RPC credentials, or leave blank to use the cookie file. |
    | `BITCOIN_DATADIR` | Path mounted into the collector container for cookie access. |
-   | `ENABLE_ZMQ` | Set to `1` only when you want ZMQ freshness metrics. Leave it commented otherwise. |
+  | `ENABLE_ZMQ` | Set to `1` only when you want ZMQ freshness metrics. Leave it at `0` otherwise. |
    | `BITCOIN_ZMQ_RAWBLOCK` / `BITCOIN_ZMQ_RAWTX` | When ZMQ metrics are enabled, ensure these match `bitcoin.conf`. Leave them commented to skip ZMQ panels. |
    | `INFLUX_SETUP_USERNAME` / `INFLUX_SETUP_PASSWORD` | Credentials used to bootstrap the bundled InfluxDB instance. |
    | `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` | Initial Grafana login. |


### PR DESCRIPTION
## Summary
- move optional ENABLE_* toggles next to the configuration blocks they control in `.env.example`
- update `docs/CONFIG.md` to describe the new grouping, including disk and ASN settings in their respective sections
- refresh the Quick Start guidance for the ZMQ flag to match the example environment file

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d26c392cfc8326b017c38a97e9712d