### PR TITLE
Respect cookie override in RPC builder

### DIFF
--- a/collector/collector/main.py
+++ b/collector/collector/main.py
@@ -36,9 +36,13 @@ LOGGER = logging.getLogger(__name__)
 def _build_rpc(config: CollectorConfig) -> BitcoinRPC:
     cookie = None
     if not config.bitcoin_rpc_user and not config.bitcoin_rpc_password:
-        cookie_path = find_cookie(config.bitcoin_datadir)
-        if cookie_path:
-            cookie = format_cookie_auth(cookie_path)
+        # Prefer an explicit cookie path override before inspecting the datadir.
+        if config.cookie_path:
+            cookie = format_cookie_auth(config.cookie_path)
+        else:
+            cookie_path = find_cookie(config.bitcoin_datadir)
+            if cookie_path:
+                cookie = format_cookie_auth(cookie_path)
     url = f"http://{config.bitcoin_rpc_host}:{config.bitcoin_rpc_port}"
     return BitcoinRPC(
         url=url,

--- a/collector/tests/test_main.py
+++ b/collector/tests/test_main.py
@@ -1,0 +1,23 @@
+from collector.config import CollectorConfig
+from collector.main import _build_rpc
+
+
+def test_build_rpc_prefers_explicit_cookie(tmp_path, monkeypatch):
+    cookie = tmp_path / "override.cookie"
+    cookie.write_text("override-user:override-pass", encoding="utf-8")
+
+    monkeypatch.setenv("BITCOIN_RPC_COOKIE_PATH", str(cookie))
+
+    config = CollectorConfig()
+    assert config.cookie_path == cookie
+
+    def _fail_find_cookie(_):  # pragma: no cover - invoked only on regression
+        raise AssertionError("_build_rpc should not inspect the datadir when a cookie override is set")
+
+    monkeypatch.setattr("collector.main.find_cookie", _fail_find_cookie)
+
+    rpc = _build_rpc(config)
+
+    assert rpc.auth is not None
+    assert rpc.auth.username == "override-user"
+    assert rpc.auth.password == "override-pass"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -19,7 +19,7 @@ services. This document explains every option and how they interact.
 | `BITCOIN_RPC_HOST` | `127.0.0.1` | Hostname/IP for the JSON-RPC endpoint. |
 | `BITCOIN_RPC_PORT` | `8332` | RPC port. Adjust for testnet/regtest. |
 | `BITCOIN_RPC_USER` / `BITCOIN_RPC_PASSWORD` | _empty_ | Explicit RPC credentials. Leave blank when using cookie auth. |
-| `BITCOIN_RPC_COOKIE_PATH` | `~/.bitcoin/.cookie` | Fallback cookie location. The collector also searches inside the mounted data directory. |
+| `BITCOIN_RPC_COOKIE_PATH` | `~/.bitcoin/.cookie` | Preferred cookie location when set. If the file is missing, the collector searches the mounted data directory. |
 | `BITCOIN_NETWORK` | `mainnet` | Tag applied to every metric. Supports custom values such as `testnet` or `signet`. |
 | `BITCOIN_DATADIR` | `~/.bitcoin` | Mounted into the collector container to access the cookie file and configuration. |
 | `BITCOIN_CHAINSTATE_DIR` | `~/.bitcoin/chainstate` | Used when disk utilisation metrics are enabled. |


### PR DESCRIPTION
## Summary
- prefer the configured Bitcoin RPC cookie override when constructing the client
- add a regression test ensuring `_build_rpc` skips datadir probing when an override is present
- clarify the configuration docs about cookie lookup precedence

## Testing
- PYTHONPATH=collector pytest

------
https://chatgpt.com/codex/tasks/task_e_68d274f9f73c8326a6f0f3c39215c9ee