### PR TITLE
Ensure Grafana loads Influx environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     container_name: btc_grafana
     restart: unless-stopped
     profiles: ["bundled-grafana"]
+    env_file:
+      - ${ENV_FILE_PATH:-.env.example}
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
@@ -29,10 +31,12 @@ services:
       GF_SERVER_HTTP_PORT: 3000
       GF_SERVER_DOMAIN: localhost
       GF_USERS_ALLOW_SIGN_UP: "false"
+      INFLUX_TOKEN: ${INFLUX_TOKEN:-__file{/var/lib/influxdb2/.influxdbv2/token}}
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - influx-data:/var/lib/influxdb2:ro
     ports:
       - "${GRAFANA_BIND_IP:-127.0.0.1}:3000:3000"
     healthcheck:

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -3,7 +3,7 @@ datasources:
   - name: InfluxDB
     type: influxdb
     access: proxy
-    url: http://influxdb:8086
+    url: ${INFLUX_URL}
     jsonData:
       version: Flux
       organization: ${INFLUX_ORG}


### PR DESCRIPTION
## Summary
- load the shared environment file for Grafana so it receives the InfluxDB configuration and fall back to the generated token when needed
- mount the Influx data volume and update the datasource provisioning to respect the configured Influx URL

## Testing
- ⚠️ `docker compose --profile bundled-influx --profile bundled-grafana up -d` *(fails: `docker` CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d27698ac308326809c5be7052236da