### PR TITLE
Guard peer metrics behind flag

### DIFF
--- a/collector/collector/main.py
+++ b/collector/collector/main.py
@@ -150,10 +150,11 @@ class CollectorService:
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=2, max=10))
     def collect_slow(self) -> None:
         LOGGER.debug("Collecting slow metrics")
-        peers = self.rpc.get_peer_info()
-        summary = peers_metrics(peers)
         points: List[Point] = []
-        points.extend(create_peer_points(self.config, summary))
+        if self.config.enable_peer_quality:
+            peers = self.rpc.get_peer_info()
+            summary = peers_metrics(peers)
+            points.extend(create_peer_points(self.config, summary))
 
         if self.config.enable_process_metrics:
             proc = collect_process_metrics()


### PR DESCRIPTION
## Summary
- gate the slow collector's peer metrics on `enable_peer_quality`
- keep slow loop writing other metrics even when no peer points are collected
- add tests that cover peer quality toggling

## Testing
- PYTHONPATH=collector pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2772fe5d48326a63a3a3442d2d7a9