### PR TITLE
Clarify datadir and chainstate configuration guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,14 +13,16 @@ BITCOIN_RPC_PORT=8332
 # Uncomment to point at a specific cookie file when autodetection fails
 #BITCOIN_RPC_COOKIE_PATH=~/.bitcoin/.cookie   # autodetect if local
 BITCOIN_NETWORK=mainnet
-# Uncomment to use a locally-mounted datadir instead of the default volume. Provide an
-# absolute path because Docker Compose does not expand `~` automatically. Leave this
-# blank when the collector runs on a different host and should not attempt local cookie
-# discovery.
+# Mount the node's data directory so the collector can read `bitcoin.conf` and the RPC
+# cookie. Always use an absolute path because Docker Compose does not expand `~`
+# automatically. Leave this blank when the collector runs on another machine and should not
+# attempt local cookie discovery.
 #BITCOIN_DATADIR=/home/bitcoin/.bitcoin
-# Uncomment to enable disk usage metrics for an external chainstate path. Set this to an
-# empty value to disable filesystem sampling when no chainstate mount is available.
-#BITCOIN_CHAINSTATE_DIR=~/.bitcoin/chainstate
+# Disk metrics look at the `chainstate` directory. By default this lives inside the data
+# directory above, but set an explicit path if you store it elsewhere. Provide an absolute
+# path that is actually mounted into the container. Set the value to an empty string to
+# disable filesystem sampling entirely when the mount is unavailable.
+#BITCOIN_CHAINSTATE_DIR=/home/bitcoin/.bitcoin/chainstate
 ENABLE_DISK_IO=1   # Samples disk utilisation for the chainstate directory when set to 1; set to 0 to skip disk metrics entirely.
 
 # Optional ZMQ metrics (opt-in). Set ENABLE_ZMQ=1 and ensure the endpoints match `bitcoin.conf`.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ streams, and pushes metrics to InfluxDB.
 
 > **Heads up:** Docker Compose does **not** expand `~` inside volume mappings. Set
 > `BITCOIN_DATADIR` in your `.env` file to the absolute path of the Bitcoin Core data
-> directory you want to mount into the collector container. Without the bind mount the
-> collector cannot read the RPC cookie or sample disk utilisation.
+> directory you want to mount into the collector container so it can read the RPC cookie and
+> configuration files. If you also want the “Chainstate Size” and “Free Space” panels to
+> populate, make sure `BITCOIN_CHAINSTATE_DIR` points at the mounted `chainstate`
+> directory (the default lives under the data directory). Leave either value empty when the
+> path is not available and the collector should behave as a remote observer.
 
 ## Components at a Glance
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -21,8 +21,8 @@ services. This document explains every option and how they interact.
 | `BITCOIN_RPC_USER` / `BITCOIN_RPC_PASSWORD` | _empty_ | Explicit RPC credentials. Leave blank when using cookie auth. |
 | `BITCOIN_RPC_COOKIE_PATH` | `~/.bitcoin/.cookie` | Preferred cookie location when set. If the file is missing, the collector searches the mounted data directory. Set to an empty string to skip cookie discovery. |
 | `BITCOIN_NETWORK` | `mainnet` | Tag applied to every metric. Supports custom values such as `testnet` or `signet`. |
-| `BITCOIN_DATADIR` | `~/.bitcoin` | Mounted into the collector container to access the cookie file and configuration. Leave blank when monitoring a remote node so the collector does not inspect local paths. |
-| `BITCOIN_CHAINSTATE_DIR` | `~/.bitcoin/chainstate` | Used when disk utilisation metrics are enabled. Clear this value to disable filesystem sampling. |
+| `BITCOIN_DATADIR` | `~/.bitcoin` | Bind-mounted into the collector container so it can read `bitcoin.conf` and the RPC cookie. Provide an absolute path; leave blank when monitoring a remote node so the collector skips local discovery. |
+| `BITCOIN_CHAINSTATE_DIR` | `~/.bitcoin/chainstate` | Filesystem path sampled for disk utilisation metrics. Defaults to a subdirectory inside the data directory; override if `chainstate` lives elsewhere or clear the value to disable sampling. |
 | `ENABLE_DISK_IO` | `1` | Samples disk usage for the chainstate directory. |
 | `ENABLE_ZMQ` | `0` | Set to `1` to collect ZMQ freshness metrics. Leave at `0` when you do not need the Grafana ZMQ panels. |
 | `BITCOIN_ZMQ_RAWBLOCK` | `tcp://127.0.0.1:28332` | Endpoint for raw block notifications. Must match `bitcoin.conf` when ZMQ metrics are enabled. |
@@ -35,8 +35,9 @@ container (see `docker-compose.yml`). Docker Compose does not expand `~`, so pro
 absolute paths (for example `/home/bitcoin/.bitcoin`). When running the collector away from
 the node, set `BITCOIN_DATADIR` (and optionally `BITCOIN_RPC_COOKIE_PATH`) to an empty value
 so the discovery step is skipped entirely. Disk utilisation sampling relies on the
-chainstate directory being available; provide a real path when the mount is present, or
-leave `BITCOIN_CHAINSTATE_DIR` empty to disable filesystem metrics even if `ENABLE_DISK_IO`
+`chainstate` directory being available; when it resides inside the data directory you can
+reuse that same mount, but override `BITCOIN_CHAINSTATE_DIR` if you keep it on a different
+volume or leave the value empty to disable filesystem metrics even if `ENABLE_DISK_IO`
 remains set to `1`. When ZMQ
 metrics remain disabled the collector skips starting the listener and simply omits the
 corresponding measurements.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -58,12 +58,18 @@ Follow the steps that match your operating system:
    |----------|-------------|
    | `BITCOIN_RPC_HOST` / `BITCOIN_RPC_PORT` | Location of your Bitcoin Core RPC endpoint. Defaults to `host.docker.internal` so the collector can reach a node running on the Docker host. |
    | `BITCOIN_RPC_USER` / `BITCOIN_RPC_PASSWORD` | RPC credentials, or leave blank to use the cookie file. |
-   | `BITCOIN_DATADIR` | Absolute path mounted into the collector container for cookie access. Docker Compose does not expand `~`, so set this explicitly (for example `/home/bitcoin/.bitcoin`). |
+   | `BITCOIN_DATADIR` | Absolute path mounted into the collector container for cookie access. Docker Compose does not expand `~`, so set this explicitly (for example `/home/bitcoin/.bitcoin`). Leave empty when the directory is not mounted. |
+   | `BITCOIN_CHAINSTATE_DIR` | Path sampled for disk usage metrics. Defaults to a `chainstate` subdirectory under the data directory; clear the value when the mount is unavailable or you do not need the dashboard panels. |
    | `ENABLE_ZMQ` | Set to `1` only when you want ZMQ freshness metrics. Leave it at `0` otherwise. |
    | `BITCOIN_ZMQ_RAWBLOCK` / `BITCOIN_ZMQ_RAWTX` | When ZMQ metrics are enabled, ensure these match `bitcoin.conf`. Leave them commented to skip ZMQ panels. |
    | `INFLUX_SETUP_USERNAME` / `INFLUX_SETUP_PASSWORD` | Credentials used to bootstrap the bundled InfluxDB instance. |
    | `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` | Initial Grafana login. Replace the placeholder password in `.env` with a unique value before exposing dashboards. |
    | `FULCRUM_STATS_URL` | Leave blank unless you have a Fulcrum/Electrs instance exposing `/stats`. |
+
+Most deployments can leave the defaults in place: the collector expects `chainstate` to live
+under the data directory. Only point `BITCOIN_CHAINSTATE_DIR` somewhere else when you store
+the database on a different volume, or clear the value when the path is not mounted and you
+want to skip the disk usage panels.
 
 3. Remember that the collector runs inside a container: use addresses that are reachable from
    that environment. When your node runs on the same machine as Docker, the bundled


### PR DESCRIPTION
## Summary
- clarify the `.env` comments for `BITCOIN_DATADIR` and `BITCOIN_CHAINSTATE_DIR`, including guidance on absolute paths, defaults, and disabling disk sampling
- expand the README and configuration docs with plain-language explanations of how the data directory and chainstate path relate to cookie discovery and dashboard metrics
- update the quickstart guide to spell out when to adjust or clear the chainstate setting and note that most users can keep the defaults

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d460a1bc288326a724e12227051bce