### PR TITLE
Add configurable TLS verification for InfluxDB writes

### DIFF
--- a/collector/collector/config.py
+++ b/collector/collector/config.py
@@ -37,6 +37,7 @@ class CollectorConfig(BaseSettings):
     influx_org: str = "bitcoin"
     influx_bucket: str = "btc_metrics"
     influx_token: str = ""
+    influx_tls_verify: bool = True
 
     scrape_interval_fast: int = 5
     scrape_interval_slow: int = 30

--- a/collector/collector/influx.py
+++ b/collector/collector/influx.py
@@ -63,11 +63,19 @@ def _escape_component(value: str, characters: tuple[str, ...]) -> str:
 
 
 class InfluxWriter:
-    def __init__(self, url: str, token: str, org: str, bucket: str) -> None:
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        org: str,
+        bucket: str,
+        verify_tls: bool = True,
+    ) -> None:
         self.url = url.rstrip("/")
         self.token = token
         self.org = org
         self.bucket = bucket
+        self.verify_tls = verify_tls
 
     def write_points(self, points: Iterable[Point]) -> None:
         lines = "\n".join(point.to_line() for point in points if point.fields)
@@ -83,6 +91,7 @@ class InfluxWriter:
                 data=lines.encode("utf-8"),
                 headers=headers,
                 timeout=10,
+                verify=self.verify_tls,
             )
             response.raise_for_status()
         except RequestException as exc:

--- a/collector/collector/main.py
+++ b/collector/collector/main.py
@@ -60,6 +60,7 @@ def _build_influx(config: CollectorConfig) -> InfluxWriter:
         token=token,
         org=config.influx_org,
         bucket=config.influx_bucket,
+        verify_tls=config.influx_tls_verify,
     )
 
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -52,11 +52,16 @@ corresponding measurements.
 | `INFLUX_RETENTION_DAYS` | `60` | Retention period applied during bootstrap. |
 | `INFLUX_SETUP_USERNAME` / `INFLUX_SETUP_PASSWORD` | `admin` / `admin123` | Credentials used once during bootstrap to create the initial API token. |
 | `INFLUX_TOKEN` | _empty_ | If provided, overrides the generated token and is used by both the collector and Grafana. |
+| `INFLUX_TLS_VERIFY` | `1` | Controls TLS certificate verification for writes. Set to `0` when using self-signed certificates. |
 | `INFLUX_BIND_IP` | `127.0.0.1` | Bind address used when exposing the InfluxDB UI through Docker Compose port mapping. |
 
 The bootstrap script writes the active token to `/var/lib/influxdb2/.influxdbv2/token`. The
 collector reads the file when `INFLUX_TOKEN` is empty, so the `influx-data` volume must stay
 mounted (read-only) on the collector service as shown in `docker-compose.yml`.
+
+> **Self-signed certificates** – When pointing the collector at an InfluxDB instance with a
+> self-signed or otherwise untrusted certificate, export `INFLUX_TLS_VERIFY=0` (or `false`).
+> Only disable verification when you control the network path and understand the risks.
 
 ## Grafana Options
 


### PR DESCRIPTION
## Summary
- allow configuring TLS verification for InfluxDB writes through `INFLUX_TLS_VERIFY`
- thread the verification flag through the Influx writer and requests client
- document how to disable verification when using self-signed certificates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ada98f288326b6dcc60e3928e196