### PR TITLE
Normalize Influx TLS verify flag handling

### DIFF
--- a/collector/collector/config.py
+++ b/collector/collector/config.py
@@ -89,6 +89,34 @@ class CollectorConfig(BaseSettings):
             raise ValueError(f"MEMPOOL_HIST_SOURCE must be one of {allowed}")
         return value_str
 
+    @field_validator("influx_tls_verify", mode="before")
+    @classmethod
+    def normalize_influx_tls_verify(cls, value: object) -> bool | object:
+        """Coerce common string and numeric values to booleans."""
+
+        if isinstance(value, bool) or value is None:
+            return value
+
+        truthy = {"1", "true", "yes", "on"}
+        falsy = {"0", "false", "no", "off"}
+
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in truthy:
+                return True
+            if normalized in falsy:
+                return False
+            raise ValueError(
+                "INFLUX_TLS_VERIFY must be one of: 1, 0, true, false, yes, no, on, off"
+            )
+
+        if isinstance(value, int):
+            if value in (0, 1):
+                return bool(value)
+            raise ValueError("INFLUX_TLS_VERIFY integer values must be 0 or 1")
+
+        return value
+
     @field_validator("scrape_interval_fast", "scrape_interval_slow")
     @classmethod
     def positive_intervals(cls, value: int) -> int:

--- a/collector/tests/test_config.py
+++ b/collector/tests/test_config.py
@@ -29,3 +29,13 @@ def test_enable_zmq_toggle(monkeypatch):
     monkeypatch.setenv("ENABLE_ZMQ", "1")
     config = CollectorConfig()
     assert config.enable_zmq is True
+
+
+def test_influx_tls_verify_coercion(monkeypatch):
+    monkeypatch.setenv("INFLUX_TLS_VERIFY", "0")
+    config = CollectorConfig()
+    assert config.influx_tls_verify is False
+
+    monkeypatch.setenv("INFLUX_TLS_VERIFY", "1")
+    config = CollectorConfig()
+    assert config.influx_tls_verify is True

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -52,7 +52,7 @@ corresponding measurements.
 | `INFLUX_RETENTION_DAYS` | `60` | Retention period applied during bootstrap. |
 | `INFLUX_SETUP_USERNAME` / `INFLUX_SETUP_PASSWORD` | `admin` / `admin123` | Credentials used once during bootstrap to create the initial API token. |
 | `INFLUX_TOKEN` | _empty_ | If provided, overrides the generated token and is used by both the collector and Grafana. |
-| `INFLUX_TLS_VERIFY` | `1` | Controls TLS certificate verification for writes. Set to `0` when using self-signed certificates. |
+| `INFLUX_TLS_VERIFY` | `1` | Controls TLS certificate verification for writes. Set to `0` when using self-signed certificates. Accepts only `1`/`0` or their boolean equivalents (`true`/`false`, `yes`/`no`, `on`/`off`). |
 | `INFLUX_BIND_IP` | `127.0.0.1` | Bind address used when exposing the InfluxDB UI through Docker Compose port mapping. |
 
 The bootstrap script writes the active token to `/var/lib/influxdb2/.influxdbv2/token`. The


### PR DESCRIPTION
## Summary
- add a Pydantic validator that coerces common string and integer inputs for `INFLUX_TLS_VERIFY`
- cover coercion behaviour with regression tests
- document the accepted literals in the configuration guide

## Testing
- pytest collector/tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68d6b41927148326a3cca6c0c92e3d7b