### PR TITLE
Add latitude/longitude metrics for peer GeoIP data

### DIFF
--- a/collector/collector/geoip.py
+++ b/collector/collector/geoip.py
@@ -31,14 +31,23 @@ class GeoIPResolver:
         if self.asn_reader:
             self.asn_reader.close()
 
-    def lookup(self, ip: str) -> dict[str, Optional[str]]:
-        result: dict[str, Optional[str]] = {"country": None, "asn": None}
+    def lookup(self, ip: str) -> dict[str, Optional[str | float]]:
+        result: dict[str, Optional[str | float]] = {
+            "country": None,
+            "asn": None,
+            "latitude": None,
+            "longitude": None,
+        }
         if self.city_reader:
             try:
                 city = self.city_reader.city(ip)
                 result["country"] = city.country.iso_code
+                result["latitude"] = city.location.latitude
+                result["longitude"] = city.location.longitude
             except Exception:  # noqa: BLE001
                 result["country"] = None
+                result["latitude"] = None
+                result["longitude"] = None
         if self.asn_reader:
             try:
                 asn = self.asn_reader.asn(ip)

--- a/collector/collector/metrics.py
+++ b/collector/collector/metrics.py
@@ -172,12 +172,12 @@ def create_peer_geo_points(
             continue
         lookup = resolver.lookup(ip)
         direction = "inbound" if peer.get("inbound") else "outbound"
-        country = lookup.get("country")
-        if country:
-            country_counts[(direction, country)] += 1
-        asn = lookup.get("asn")
-        if asn:
-            asn_counts[(direction, asn)] += 1
+        country_value = lookup.get("country")
+        if isinstance(country_value, str) and country_value:
+            country_counts[(direction, country_value)] += 1
+        asn_value = lookup.get("asn")
+        if isinstance(asn_value, str) and asn_value:
+            asn_counts[(direction, asn_value)] += 1
         latitude = lookup.get("latitude")
         longitude = lookup.get("longitude")
         if (
@@ -187,8 +187,8 @@ def create_peer_geo_points(
             coord_entries.append(
                 (
                     direction,
-                    country if isinstance(country, str) else None,
-                    asn if isinstance(asn, str) else None,
+                    country_value if isinstance(country_value, str) else None,
+                    asn_value if isinstance(asn_value, str) else None,
                     ip,
                     float(latitude),
                     float(longitude),
@@ -215,7 +215,7 @@ def create_peer_geo_points(
             .field("peer_count", float(count))
         )
 
-    for direction, country, asn, ip, latitude, longitude in coord_entries:
+    for direction, country_opt, asn_opt, ip, latitude, longitude in coord_entries:
         point = (
             Point("peer_geo_coords")
             .tag("network", config.bitcoin_network)
@@ -225,10 +225,10 @@ def create_peer_geo_points(
             .field("latitude", latitude)
             .field("longitude", longitude)
         )
-        if country:
-            point = point.tag("country", country)
-        if asn:
-            point = point.tag("asn", asn)
+        if country_opt is not None:
+            point = point.tag("country", country_opt)
+        if asn_opt is not None:
+            point = point.tag("asn", asn_opt)
         points.append(point)
 
     return points


### PR DESCRIPTION
## Summary
- include latitude and longitude values in GeoIP lookups when city data is available
- emit per-peer geo coordinate points alongside existing peer geo/asn metrics
- extend unit tests to cover coordinate enrichment

## Testing
- `PYTHONPATH=. pytest collector/tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6dd08a4748326a8938705e10349e3