### PR TITLE
Fix Grafana dashboards and geomap peers

### DIFF
--- a/grafana/dashboards/01_Overview.json
+++ b/grafana/dashboards/01_Overview.json
@@ -1,61 +1,352 @@
 {
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
   "id": null,
-  "title": "01 - Overview",
-  "uid": "btc-overview",
-  "schemaVersion": 38,
-  "version": 1,
+  "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "type": "stat",
-      "title": "Block Lag",
-      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 0},
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "blocks"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -5m)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field == \"block_lag\")\n  |> last()",
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -5m)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field == \"block_lag\")\n  |> last()",
+          "queryType": "flux",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Block Lag",
+      "type": "stat"
     },
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "blocks"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 6,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -6h)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field =~ /best_height|headers_height/)\n  |> aggregateWindow(every: 1m, fn: last, createEmpty: false)\n  |> yield(name: \"series\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "Headers vs Blocks",
-      "gridPos": {"h": 8, "w": 12, "x": 4, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -6h)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field =~ /best_height|headers_height/)",
-          "format": "time_series"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "memory_rss_mb"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "mbytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 6
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -6h)\n  |> filter(fn: (r) => r._measurement == \"process\" and r._field =~ /cpu_percent|memory_rss_mb/)\n  |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)\n  |> yield(name: \"resources\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "CPU & Memory",
-      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 4},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -6h)\n  |> filter(fn: (r) => r._measurement == \"process\" and r._field =~ /cpu_percent|memory_rss_mb/)",
-          "format": "time_series"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "stat",
-      "title": "Chainstate Size (GB)",
-      "gridPos": {"h": 4, "w": 4, "x": 16, "y": 0},
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 250
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "gbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 9
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"filesystem\" and r._field == \"chainstate_gb\")\n  |> last()",
-          "format": "time_series"
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -1h)\n  |> filter(fn: (r) => r._measurement == \"filesystem\" and r._field == \"chainstate_gb\")\n  |> last()",
+          "queryType": "flux",
+          "refId": "A"
         }
-      ]
+      ],
+      "title": "Chainstate Size (GB)",
+      "type": "stat"
     }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "bitcoin"
   ],
   "templating": {
     "list": []
@@ -63,5 +354,11 @@
   "time": {
     "from": "now-6h",
     "to": "now"
-  }
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "01 - Overview",
+  "uid": "btc-overview",
+  "version": 1,
+  "weekStart": ""
 }

--- a/grafana/dashboards/02_Sync_Health.json
+++ b/grafana/dashboards/02_Sync_Health.json
@@ -1,60 +1,385 @@
 {
-  "title": "02 - Sync Health",
-  "uid": "btc-sync",
-  "schemaVersion": 38,
-  "version": 1,
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -12h)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field == \"verification_progress\")\n  |> aggregateWindow(every: 1m, fn: last, createEmpty: false)\n  |> yield(name: \"progress\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "Verification Progress",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -12h)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field == \"verification_progress\")"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Seconds",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -12h)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field == \"block_interval_seconds\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"interval\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "Block Interval (s)",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -12h)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field == \"block_interval_seconds\")"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Events/min",
+            "axisPlacement": "auto",
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepBefore",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -12h)\n  |> filter(fn: (r) => r._measurement == \"zmq\" and r._field == \"rawblock_per_min\")\n  |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)\n  |> yield(name: \"zmq\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "ZMQ Rawblock Rate",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -12h)\n  |> filter(fn: (r) => r._measurement == \"zmq\" and r._field == \"rawblock_per_min\")"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Reorg Depth",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisLabel": "Blocks",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "blocks"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -30d)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field == \"max_reorg_depth\")"
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -30d)\n  |> filter(fn: (r) => r._measurement == \"blockchain\" and r._field == \"max_reorg_depth\")\n  |> aggregateWindow(every: 1d, fn: max, createEmpty: false)\n  |> yield(name: \"reorg\")",
+          "queryType": "flux",
+          "refId": "A"
         }
-      ]
+      ],
+      "title": "Reorg Depth",
+      "type": "timeseries"
     }
   ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "bitcoin"
+  ],
+  "templating": {
+    "list": []
+  },
   "time": {
     "from": "now-12h",
     "to": "now"
-  }
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "02 - Sync Health",
+  "uid": "btc-sync",
+  "version": 1,
+  "weekStart": ""
 }

--- a/grafana/dashboards/03_Mempool_Fees.json
+++ b/grafana/dashboards/03_Mempool_Fees.json
@@ -1,62 +1,376 @@
 {
-  "title": "03 - Mempool & Fees",
-  "uid": "btc-mempool",
-  "schemaVersion": 38,
-  "version": 1,
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Transactions",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"mempool\" and r._field == \"tx_count\")\n  |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)\n  |> yield(name: \"txs\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "Mempool Transactions",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"mempool\" and r._field == \"tx_count\")"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "MB",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "mbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"mempool\" and r._field == \"vsize_mb\")\n  |> aggregateWindow(every: 1m, fn: mean, createEmpty: false)\n  |> yield(name: \"vsize\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "Virtual Size (MB)",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"mempool\" and r._field == \"vsize_mb\")"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "sat/vB",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"mempool\" and r._field =~ /fee_fast|fee_slow/)\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"fees\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "Fee Estimates (sat/vB)",
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"mempool\" and r._field =~ /fee_fast|fee_slow/)",
-          "format": "time_series"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "bargauge",
-      "title": "Fee Histogram",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#56A64B",
+                "value": null
+              },
+              {
+                "color": "#FF9830",
+                "value": 50
+              },
+              {
+                "color": "#FF4D4D",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 8,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -5m)\n  |> filter(fn: (r) => r._measurement == \"mempool_hist\")\n  |> last()",
-          "format": "table"
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -5m)\n  |> filter(fn: (r) => r._measurement == \"mempool_hist\")\n  |> last()\n  |> pivot(rowKey: [\"_time\"], columnKey: [\"bin\"], valueColumn: \"_value\")\n  |> drop(columns: [\"_start\", \"_stop\", \"_time\"])",
+          "queryType": "flux",
+          "refId": "A"
         }
-      ]
+      ],
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "*"
+              }
+            ]
+          }
+        }
+      ],
+      "title": "Fee Histogram",
+      "type": "bargauge"
     }
   ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "bitcoin"
+  ],
+  "templating": {
+    "list": []
+  },
   "time": {
     "from": "now-24h",
     "to": "now"
-  }
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "03 - Mempool & Fees",
+  "uid": "btc-mempool",
+  "version": 1,
+  "weekStart": ""
 }

--- a/grafana/dashboards/04_Peers_Geo.json
+++ b/grafana/dashboards/04_Peers_Geo.json
@@ -1,75 +1,516 @@
 {
-  "title": "04 - Peers & Geo",
-  "uid": "btc-peers",
-  "schemaVersion": 38,
-  "version": 1,
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
   "panels": [
     {
-      "type": "worldmap",
-      "title": "Peers by Country",
-      "gridPos": {"h": 10, "w": 12, "x": 0, "y": 0},
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 18,
+        "w": 13,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "basemap": {
+          "config": {
+            "style": "dark"
+          },
+          "name": "CartoDB Dark"
+        },
+        "controls": {
+          "mouseWheelZoom": true,
+          "showAttribution": true,
+          "showDebug": false,
+          "showScale": false,
+          "showZoom": true
+        },
+        "dataConfig": {
+          "auto": false,
+          "labelFields": [
+            "peer_id",
+            "country",
+            "city",
+            "asn"
+          ],
+          "latitudeField": "latitude",
+          "longitudeField": "longitude",
+          "metricField": "count"
+        },
+        "featureStyle": {
+          "color": {
+            "fixed": "#33a1fd",
+            "mode": "fixed"
+          },
+          "opacity": 80,
+          "sizeConfig": {
+            "byValue": true,
+            "field": "count",
+            "max": 24,
+            "min": 4,
+            "mode": "linear"
+          }
+        },
+        "initialView": {
+          "lat": 20,
+          "lon": 0,
+          "zoom": 1.5
+        },
+        "layerTypes": [
+          "markers"
+        ],
+        "view": {
+          "lat": 20,
+          "lon": 0,
+          "zoom": 1.5
+        }
+      },
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -5m)\n  |> filter(fn: (r) => r._measurement == \"peers_geo\" and r._field == \"count\")\n  |> last()"
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"peers_geo\" and (r._field == \"lat\" or r._field == \"lon\" or r._field == \"country\" or r._field == \"city\" or r._field == \"asn\" or r._field == \"count\"))\n  |> last()\n  |> pivot(rowKey: [\"peer_id\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n  |> rename(columns: {lat: \"latitude\", lon: \"longitude\"})\n  |> keep(columns: [\"peer_id\", \"latitude\", \"longitude\", \"country\", \"city\", \"asn\", \"count\"])\n  |> map(fn: (r) => ({ r with count: if exists r.count then float(v: r.count) else 1.0 }))",
+          "queryType": "flux",
+          "refId": "A"
         }
-      ]
+      ],
+      "title": "Peers by Location",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "number",
+                "targetField": "latitude"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "longitude"
+              },
+              {
+                "destinationType": "number",
+                "targetField": "count"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "geomap"
     },
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Peers",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 11,
+        "x": 13,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"peers\" and r._field =~ /total|inbound|outbound/)\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"peers\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "Peer Count",
-      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 0},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"peers\" and r._field =~ /total|inbound|outbound/)",
-          "format": "time_series"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "table",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "mode": "gradient"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 11,
+        "x": 13,
+        "y": 9
+      },
+      "id": 6,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": true,
+          "fields": ""
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -10m)\n  |> filter(fn: (r) => r._measurement == \"peers_asn\")\n  |> last()\n  |> pivot(rowKey: [\"asn\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n  |> keep(columns: [\"asn\", \"count\", \"organization\"])",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "Top ASNs",
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
-      "targets": [
+      "transformations": [
         {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -5m)\n  |> filter(fn: (r) => r._measurement == \"peers_asn\")\n  |> last()",
-          "format": "table"
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "count",
+                "order": "desc"
+              }
+            ]
+          }
         }
-      ]
+      ],
+      "type": "table"
     },
     {
-      "type": "timeseries",
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Milliseconds",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 150
+              },
+              {
+                "color": "red",
+                "value": 300
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 13,
+        "x": 0,
+        "y": 18
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"peers\" and r._field == \"ping_p95_ms\")\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"latency\")",
+          "queryType": "flux",
+          "refId": "A"
+        }
+      ],
       "title": "Peer Ping p95 (ms)",
-      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 10},
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"peers\" and r._field == \"ping_p95_ms\")"
-        }
-      ]
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Peer Churn",
-      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 16},
+      "datasource": {
+        "type": "influxdb",
+        "uid": "-100"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Peers/min",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 13,
+        "x": 0,
+        "y": 26
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.2",
       "targets": [
         {
-          "refId": "A",
-          "datasource": {"type": "influxdb", "uid": "-100"},
-          "query": "from(bucket: \"$INFLUX_BUCKET\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"peers\" and r._field =~ /joins_per_min|leaves_per_min/)",
-          "format": "time_series"
+          "datasource": {
+            "type": "influxdb",
+            "uid": "-100"
+          },
+          "query": "from(bucket: \"$__env{INFLUX_BUCKET}\")\n  |> range(start: -24h)\n  |> filter(fn: (r) => r._measurement == \"peers\" and r._field =~ /joins_per_min|leaves_per_min/)\n  |> aggregateWindow(every: 5m, fn: mean, createEmpty: false)\n  |> yield(name: \"churn\")",
+          "queryType": "flux",
+          "refId": "A"
         }
-      ]
+      ],
+      "title": "Peer Churn",
+      "type": "timeseries"
     }
   ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "bitcoin"
+  ],
+  "templating": {
+    "list": []
+  },
   "time": {
     "from": "now-24h",
     "to": "now"
-  }
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "04 - Peers & Geo",
+  "uid": "btc-peers",
+  "version": 1,
+  "weekStart": ""
 }


### PR DESCRIPTION
## Summary
- re-export the four Grafana dashboards with full panel metadata so Grafana stops requesting a missing plugin
- update every Flux target to use the $__env{INFLUX_BUCKET} macro and add smoothing/units for key metrics
- replace the legacy worldmap panel with a geomap that plots peers by their latitude/longitude fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6daf1d57083269fdc1581664b268a