### PR TITLE
Update external Grafana instructions for datasource UID rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ streams, and pushes metrics to InfluxDB.
 | GeoIP     | Periodically downloads MaxMind GeoLite2 databases for peer geography insights. | Managed via the `geoipupdate` container and configuration template in `geoip/`. |
 | Dashboards | Ready-to-use Grafana dashboards grouped by topic (overview, sync, mempool, peers). | JSON exports located in `grafana/dashboards`. |
 
+When you import the dashboards into an existing Grafana instance, rewrite the data source UID
+as outlined in [External Grafana](docs/OPERATIONS.md#external-grafana) so the panels resolve
+against your own InfluxDB connection.
+
 ## Data Flow Summary
 
 1. **Bitcoin Core** exposes JSON-RPC, ZMQ block/transaction streams, and optionally Fulcrum

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -125,7 +125,10 @@ want to skip the disk usage panels.
 1. Navigate to `http://127.0.0.1:3000/` (or the host/IP you configured) and log in with the
    credentials from `.env`.
 2. Grafana auto-loads the dashboards from `grafana/dashboards`. Look for the “Bitcoin Node
-   Overview” dashboard to validate data is flowing.
+   Overview” dashboard to validate data is flowing. When you plan to import the dashboards
+   into an existing Grafana instead of the bundled container, follow the
+   [External Grafana](OPERATIONS.md#external-grafana) workflow to rewrite the data source UID
+   before importing.
 
 ## 5. Validate Metrics
 


### PR DESCRIPTION
## Summary
- document how exported dashboards reference a fixed Grafana datasource UID and provide sed/jq rewrites before import
- add UI breadcrumbs for finding the datasource UID and cross-link the workflow from the quick start guide and README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e4357f788326b201b7c3d7afcddb