### PR TITLE
Fix process metrics logger extra key

### DIFF
--- a/collector/collector/process_metrics.py
+++ b/collector/collector/process_metrics.py
@@ -22,7 +22,9 @@ def collect_process_metrics(process_name: str = "bitcoind") -> Optional[dict[str
                 "memory_rss_mb": float(getattr(memory, "rss", 0) / (1024 * 1024) if memory else 0),
                 "open_files": float(proc.info.get("num_fds", 0)),
             }
-    LOGGER.debug("Process not found for metrics collection", extra={"process": process_name})
+    LOGGER.debug(
+        "Process not found for metrics collection", extra={"process_name": process_name}
+    )
     return None
 
 


### PR DESCRIPTION
## Summary
- update the process metrics logger to avoid using the reserved "process" key in log extras

## Testing
- python -c "from collector.process_metrics import collect_process_metrics; print(collect_process_metrics('definitely_not_real_process'))"

------
https://chatgpt.com/codex/tasks/task_e_68d939c86fd48326bfa0608674182ec8